### PR TITLE
fix: Reverting generics and minor fixes

### DIFF
--- a/chains/evm/chain.go
+++ b/chains/evm/chain.go
@@ -18,11 +18,11 @@ type EventListener interface {
 }
 
 type ProposalExecutor interface {
-	Execute(props []*proposal.Proposal[any]) error
+	Execute(props []*proposal.Proposal) error
 }
 
 type MessageHandler interface {
-	HandleMessage(m *message.Message[any]) (*proposal.Proposal[any], error)
+	HandleMessage(m *message.Message) (*proposal.Proposal, error)
 }
 
 // EVMChain is struct that aggregates all data required for
@@ -55,11 +55,11 @@ func (c *EVMChain) PollEvents(ctx context.Context) {
 	go c.listener.ListenToEvents(ctx, c.startBlock)
 }
 
-func (c *EVMChain) ReceiveMessage(m *message.Message[any]) (*proposal.Proposal[any], error) {
+func (c *EVMChain) ReceiveMessage(m *message.Message) (*proposal.Proposal, error) {
 	return c.messageHandler.HandleMessage(m)
 }
 
-func (c *EVMChain) Write(props []*proposal.Proposal[any]) error {
+func (c *EVMChain) Write(props []*proposal.Proposal) error {
 	err := c.executor.Execute(props)
 	if err != nil {
 		c.logger.Err(err).Msgf("error writing proposals %+v on network %d", props, c.DomainID())

--- a/chains/substrate/chain.go
+++ b/chains/substrate/chain.go
@@ -11,11 +11,11 @@ import (
 )
 
 type ProposalExecutor interface {
-	Execute(props []*proposal.Proposal[any]) error
+	Execute(props []*proposal.Proposal) error
 }
 
 type MessageHandler interface {
-	HandleMessage(m *message.Message[any]) (*proposal.Proposal[any], error)
+	HandleMessage(m *message.Message) (*proposal.Proposal, error)
 }
 
 type EventListener interface {
@@ -49,11 +49,11 @@ func (c *SubstrateChain) PollEvents(ctx context.Context) {
 	go c.listener.ListenToEvents(ctx, c.startBlock)
 }
 
-func (c *SubstrateChain) ReceiveMessage(m *message.Message[any]) (*proposal.Proposal[any], error) {
+func (c *SubstrateChain) ReceiveMessage(m *message.Message) (*proposal.Proposal, error) {
 	return c.messageHandler.HandleMessage(m)
 }
 
-func (c *SubstrateChain) Write(props []*proposal.Proposal[any]) error {
+func (c *SubstrateChain) Write(props []*proposal.Proposal) error {
 	err := c.executor.Execute(props)
 	if err != nil {
 		c.logger.Err(err).Msgf("error writing proposals %+v on network %d", props, c.DomainID())

--- a/mock/message.go
+++ b/mock/message.go
@@ -40,10 +40,10 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 }
 
 // HandleMessage mocks base method.
-func (m_2 *MockHandler) HandleMessage(m *message.Message[any]) (*proposal.Proposal[any], error) {
+func (m_2 *MockHandler) HandleMessage(m *message.Message) (*proposal.Proposal, error) {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "HandleMessage", m)
-	ret0, _ := ret[0].(*proposal.Proposal[any])
+	ret0, _ := ret[0].(*proposal.Proposal)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mock/relayer.go
+++ b/mock/relayer.go
@@ -67,10 +67,10 @@ func (mr *MockRelayedChainMockRecorder) PollEvents(ctx any) *gomock.Call {
 }
 
 // ReceiveMessage mocks base method.
-func (m_2 *MockRelayedChain) ReceiveMessage(m *message.Message[any]) (*proposal.Proposal[any], error) {
+func (m_2 *MockRelayedChain) ReceiveMessage(m *message.Message) (*proposal.Proposal, error) {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "ReceiveMessage", m)
-	ret0, _ := ret[0].(*proposal.Proposal[any])
+	ret0, _ := ret[0].(*proposal.Proposal)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -82,7 +82,7 @@ func (mr *MockRelayedChainMockRecorder) ReceiveMessage(m any) *gomock.Call {
 }
 
 // Write mocks base method.
-func (m *MockRelayedChain) Write(proposals []*proposal.Proposal[any]) error {
+func (m *MockRelayedChain) Write(proposals []*proposal.Proposal) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", proposals)
 	ret0, _ := ret[0].(error)

--- a/relayer/message/handler.go
+++ b/relayer/message/handler.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Handler interface {
-	HandleMessage(m *Message[any]) (*proposal.Proposal[any], error)
+	HandleMessage(m *Message) (*proposal.Proposal, error)
 }
 
 type MessageHandler struct {
@@ -21,7 +21,7 @@ func NewMessageHandler() *MessageHandler {
 }
 
 // HandlerMessage calls associated handler for that message type and returns a proposal to be submitted on-chain
-func (h *MessageHandler) HandleMessage(m *Message[any]) (*proposal.Proposal[any], error) {
+func (h *MessageHandler) HandleMessage(m *Message) (*proposal.Proposal, error) {
 	mh, ok := h.handlers[m.Type]
 	if !ok {
 		return nil, fmt.Errorf("no handler found for type %s", m.Type)

--- a/relayer/message/handler_test.go
+++ b/relayer/message/handler_test.go
@@ -63,7 +63,12 @@ func (s *MessageHandlerTestSuite) TestHandleMessageWithValidType() {
 	mh := message.NewMessageHandler()
 	mh.RegisterMessageHandler("valid", s.mockHandler)
 
-	msg := message.NewMessage(1, 2, nil, "valid")
+	msg := &message.Message{
+		Source:      1,
+		Destination: 2,
+		Data:        nil,
+		Type:        "valid",
+	}
 	prop, err := mh.HandleMessage(msg)
 
 	s.Nil(err)

--- a/relayer/message/handler_test.go
+++ b/relayer/message/handler_test.go
@@ -29,7 +29,7 @@ func (s *MessageHandlerTestSuite) SetupTest() {
 func (s *MessageHandlerTestSuite) TestHandleMessageWithoutRegisteredHandler() {
 	mh := message.NewMessageHandler()
 
-	_, err := mh.HandleMessage(&message.Message[any]{Type: "invalid"})
+	_, err := mh.HandleMessage(&message.Message{Type: "invalid"})
 
 	s.NotNil(err)
 }
@@ -38,7 +38,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessageWithInvalidType() {
 	mh := message.NewMessageHandler()
 	mh.RegisterMessageHandler("invalid", s.mockHandler)
 
-	_, err := mh.HandleMessage(&message.Message[any]{Type: "valid"})
+	_, err := mh.HandleMessage(&message.Message{Type: "valid"})
 
 	s.NotNil(err)
 }
@@ -49,13 +49,13 @@ func (s *MessageHandlerTestSuite) TestHandleMessageHandlerReturnsError() {
 	mh := message.NewMessageHandler()
 	mh.RegisterMessageHandler("valid", s.mockHandler)
 
-	_, err := mh.HandleMessage(&message.Message[any]{Type: "valid"})
+	_, err := mh.HandleMessage(&message.Message{Type: "valid"})
 
 	s.NotNil(err)
 }
 
 func (s *MessageHandlerTestSuite) TestHandleMessageWithValidType() {
-	expectedProp := &proposal.Proposal[any]{
+	expectedProp := &proposal.Proposal{
 		Type: "prop",
 	}
 	s.mockHandler.EXPECT().HandleMessage(gomock.Any()).Return(expectedProp, nil)
@@ -63,7 +63,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessageWithValidType() {
 	mh := message.NewMessageHandler()
 	mh.RegisterMessageHandler("valid", s.mockHandler)
 
-	msg := message.NewMessage[any](1, 2, nil, "valid")
+	msg := message.NewMessage(1, 2, nil, "valid")
 	prop, err := mh.HandleMessage(msg)
 
 	s.Nil(err)

--- a/relayer/message/message.go
+++ b/relayer/message/message.go
@@ -7,17 +7,3 @@ type Message struct {
 	Data        interface{} // Data associated with the message
 	Type        MessageType // Message type
 }
-
-func NewMessage(
-	source uint8,
-	destination uint8,
-	data interface{},
-	msgType MessageType,
-) *Message {
-	return &Message{
-		source,
-		destination,
-		data,
-		msgType,
-	}
-}

--- a/relayer/message/message.go
+++ b/relayer/message/message.go
@@ -1,20 +1,20 @@
 package message
 
 type MessageType string
-type Message[T any] struct {
+type Message struct {
 	Source      uint8       // Source where message was initiated
 	Destination uint8       // Destination chain of message
-	Data        T           // Data associated with the message
+	Data        interface{} // Data associated with the message
 	Type        MessageType // Message type
 }
 
-func NewMessage[T any](
+func NewMessage(
 	source uint8,
 	destination uint8,
-	data T,
+	data interface{},
 	msgType MessageType,
-) *Message[T] {
-	return &Message[T]{
+) *Message {
+	return &Message{
 		source,
 		destination,
 		data,

--- a/relayer/proposal/proposal.go
+++ b/relayer/proposal/proposal.go
@@ -1,15 +1,15 @@
 package proposal
 
 type ProposalType string
-type Proposal[T any] struct {
+type Proposal struct {
 	Source      uint8
 	Destination uint8
-	Data        T
+	Data        interface{}
 	Type        ProposalType
 }
 
-func NewProposal[T any](source, destination uint8, data T, propType ProposalType) *Proposal[T] {
-	return &Proposal[T]{
+func NewProposal(source, destination uint8, data []byte, propType ProposalType) *Proposal {
+	return &Proposal{
 		Source:      source,
 		Destination: destination,
 		Data:        data,

--- a/relayer/proposal/proposal.go
+++ b/relayer/proposal/proposal.go
@@ -7,12 +7,3 @@ type Proposal struct {
 	Data        interface{}
 	Type        ProposalType
 }
-
-func NewProposal(source, destination uint8, data []byte, propType ProposalType) *Proposal {
-	return &Proposal{
-		Source:      source,
-		Destination: destination,
-		Data:        data,
-		Type:        propType,
-	}
-}

--- a/relayer/relayer_test.go
+++ b/relayer/relayer_test.go
@@ -46,8 +46,8 @@ func (s *RouteTestSuite) TestStartListensOnChannel() {
 		chains,
 	)
 
-	msgChan := make(chan []*message.Message[any], 1)
-	msgChan <- []*message.Message[any]{
+	msgChan := make(chan []*message.Message, 1)
+	msgChan <- []*message.Message{
 		{Destination: 1},
 	}
 	relayer.Start(ctx, msgChan)
@@ -63,7 +63,7 @@ func (s *RouteTestSuite) TestReceiveMessageFails() {
 		chains,
 	)
 
-	relayer.route([]*message.Message[any]{
+	relayer.route([]*message.Message{
 		{Destination: 1},
 	})
 }
@@ -76,14 +76,14 @@ func (s *RouteTestSuite) TestAvoidWriteWithoutProposals() {
 		chains,
 	)
 
-	relayer.route([]*message.Message[any]{
+	relayer.route([]*message.Message{
 		{Destination: 1},
 	})
 }
 
 func (s *RouteTestSuite) TestWriteFails() {
-	props := make([]*proposal.Proposal[any], 1)
-	prop := &proposal.Proposal[any]{}
+	props := make([]*proposal.Proposal, 1)
+	prop := &proposal.Proposal{}
 	props[0] = prop
 	s.mockRelayedChain.EXPECT().ReceiveMessage(gomock.Any()).Return(prop, nil)
 	s.mockRelayedChain.EXPECT().Write(props).Return(fmt.Errorf("error"))
@@ -94,14 +94,14 @@ func (s *RouteTestSuite) TestWriteFails() {
 		chains,
 	)
 
-	relayer.route([]*message.Message[any]{
+	relayer.route([]*message.Message{
 		{Destination: 1},
 	})
 }
 
 func (s *RouteTestSuite) TestWritesToChain() {
-	props := make([]*proposal.Proposal[any], 1)
-	prop := &proposal.Proposal[any]{}
+	props := make([]*proposal.Proposal, 1)
+	prop := &proposal.Proposal{}
 	props[0] = prop
 	s.mockRelayedChain.EXPECT().ReceiveMessage(gomock.Any()).Return(prop, nil)
 	s.mockRelayedChain.EXPECT().Write(props).Return(nil)
@@ -111,7 +111,7 @@ func (s *RouteTestSuite) TestWritesToChain() {
 		chains,
 	)
 
-	relayer.route([]*message.Message[any]{
+	relayer.route([]*message.Message{
 		{Destination: 1},
 	})
 }


### PR DESCRIPTION
Considering that generics ultimately do not provide a more efficient solution, the repository needs to be reverted to its previous state. 

Also, minor changes were made. Both message and proposal constructors were deleted due to the fact that they should be written on the importing side because of the custom `interface{}` type.


